### PR TITLE
NOT TO MERGE: test ops 3.4.0b3

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,7 +4,7 @@ type: "charm"
 bases:
   - build-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"
     run-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -32,7 +32,7 @@ description: |
 min-juju-version: 2.8.0  # charm storage in state
 version: 1
 series:
-  - focal
+  - jammy
 requires:
   db:
     interface: pgsql

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ops
+ops==3.4.0b3
 ops-lib-pgsql


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Bump ops to 3.4.0b3 to ensure that nothing will break.

### Rationale

Ops changes the implementation of the Juju hook commands in 3.4.0, want to maximise confidence that no charms will notice the change.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->

Not for merging - when the tests are passing, I'll close the PR.