### PR TITLE
feat(grafana): add grafana dashboard (ISD-718)

### DIFF
--- a/.jujuignore
+++ b/.jujuignore
@@ -1,4 +1,5 @@
 /venv
 *.py[cod]
 *.charm
+*.rock
 /.github

--- a/cos_custom/grafana_dashboards/mattermost.json
+++ b/cos_custom/grafana_dashboards/mattermost.json
@@ -570,7 +570,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "rate(mattermost_http_requests_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])",
+          "expr": "sum(rate(mattermost_http_requests_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m])) by (juju_model, juju_application, juju_unit)",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -580,7 +580,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_http_requests_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m]))",
+          "expr": "sum(rate(mattermost_http_requests_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -675,7 +675,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_db_store_time_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit)",
+          "expr": "sum(rate(mattermost_db_store_time_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit)",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -685,7 +685,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_db_store_time_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(mattermost_db_store_time_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -781,7 +781,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
           "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
@@ -791,7 +791,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(mattermost_api_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_api_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
           "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
@@ -887,7 +887,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_db_store_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_db_store_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
           "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
@@ -897,7 +897,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(mattermost_db_store_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_db_store_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
           "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
@@ -992,7 +992,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_db_store_time_count{method=~\"$top_db_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
+          "expr": "sum(increase(mattermost_db_store_time_count{method=~\"$top_db_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
           "interval": "",
           "legendFormat": "{{method}}",
           "refId": "A"
@@ -1087,7 +1087,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_api_time_count{handler=~\"$top_api_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
+          "expr": "sum(increase(mattermost_api_time_count{handler=~\"$top_api_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
           "interval": "",
           "legendFormat": "{{handler}}",
           "refId": "A"
@@ -1186,7 +1186,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_db_store_time_sum{method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method) / sum(increase(mattermost_db_store_time_count{method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
+          "expr": "sum(increase(mattermost_db_store_time_sum{method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, method) / sum(increase(mattermost_db_store_time_count{method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
           "interval": "",
           "legendFormat": "{{method}}",
           "refId": "A"
@@ -1285,7 +1285,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_api_time_sum{handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler) / sum(increase(mattermost_api_time_count{handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
+          "expr": "sum(increase(mattermost_api_time_sum{handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, handler) / sum(increase(mattermost_api_time_count{handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
           "interval": "",
           "legendFormat": "{{handler}}",
           "refId": "A"
@@ -1381,7 +1381,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])\n  )\n)",
           "interval": "",
           "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
@@ -1391,7 +1391,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])\n  )\n)",
           "interval": "",
           "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
@@ -1487,7 +1487,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])\n  )\n)",
           "interval": "",
           "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
@@ -1497,7 +1497,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])\n  )\n)",
           "interval": "",
           "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
@@ -1595,7 +1595,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "mattermost_http_websockets_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "mattermost_http_websockets_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}",
           "interval": "",
           "legendFormat": "{{juju_unit}} - {{ origin_client}}",
           "range": true,
@@ -1606,7 +1606,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(mattermost_http_websockets_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(mattermost_http_websockets_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -1617,7 +1617,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(mattermost_http_websockets_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}) by (juju_model, juju_application, juju_unit, origin_client)",
+          "expr": "sum(mattermost_http_websockets_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}) by (juju_model, juju_application, juju_unit, origin_client)",
           "hide": false,
           "interval": "",
           "legendFormat": "Total - {{ origin_client }}",
@@ -1714,7 +1714,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(mattermost_db_master_connections_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(mattermost_db_master_connections_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"})",
           "interval": "",
           "legendFormat": "master",
           "refId": "A"
@@ -1724,7 +1724,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(mattermost_db_read_replica_connections_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(mattermost_db_read_replica_connections_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"})",
           "interval": "",
           "legendFormat": "replica",
           "refId": "B"
@@ -1820,7 +1820,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(go_sql_open_connections{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(go_sql_open_connections{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"})",
           "hide": false,
           "legendFormat": "open_conns",
           "range": true,
@@ -1832,7 +1832,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(go_sql_in_use_connections{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(go_sql_in_use_connections{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"})",
           "hide": false,
           "legendFormat": "in_use_conns",
           "range": true,
@@ -1844,7 +1844,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_wait_count_total{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(go_sql_wait_count_total{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
           "hide": false,
           "legendFormat": "wait_count",
           "range": true,
@@ -1856,7 +1856,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=~\"replica.*\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=~\"replica.*\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
           "hide": false,
           "legendFormat": "max_idle_closed",
           "range": true,
@@ -1868,7 +1868,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=~\"replica.*\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=~\"replica.*\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
           "hide": false,
           "legendFormat": "max_idle_time_closed",
           "range": true,
@@ -1965,7 +1965,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(go_sql_open_connections{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(go_sql_open_connections{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"})",
           "hide": false,
           "legendFormat": "open_conns",
           "range": true,
@@ -1977,7 +1977,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(go_sql_in_use_connections{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(go_sql_in_use_connections{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"})",
           "hide": false,
           "legendFormat": "in_use_conns",
           "range": true,
@@ -1989,7 +1989,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_wait_count_total{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(go_sql_wait_count_total{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
           "hide": false,
           "legendFormat": "wait_count",
           "range": true,
@@ -2001,7 +2001,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
           "hide": false,
           "legendFormat": "max_idle_closed",
           "range": true,
@@ -2013,7 +2013,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=\"master\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=\"master\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
           "hide": false,
           "legendFormat": "max_idle_time_closed",
           "range": true,
@@ -2080,7 +2080,7 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -2110,7 +2110,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "mattermost_db_replica_lag_time{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "mattermost_db_replica_lag_time{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -2232,7 +2232,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "mattermost_cluster_cluster_health_score{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "mattermost_cluster_cluster_health_score{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -2328,7 +2328,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
           "interval": "",
           "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
@@ -2338,7 +2338,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
           "interval": "",
           "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
@@ -2433,7 +2433,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit)",
+          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit)",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -2443,7 +2443,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -2564,7 +2564,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "mattermost_jobs_active{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "mattermost_jobs_active{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -2574,7 +2574,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(mattermost_jobs_active{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(mattermost_jobs_active{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -2695,7 +2695,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "irate(mattermost_process_cpu_seconds_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])* 100",
+          "expr": "irate(mattermost_process_cpu_seconds_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])* 100",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -2790,7 +2790,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "go_memstats_heap_inuse_bytes{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "go_memstats_heap_inuse_bytes{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -2885,7 +2885,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "go_goroutines{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "go_goroutines{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -2895,7 +2895,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(go_goroutines{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(go_goroutines{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"

--- a/cos_custom/grafana_dashboards/mattermost.json
+++ b/cos_custom/grafana_dashboards/mattermost.json
@@ -256,7 +256,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(mattermost_websocket_broadcasts_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, name)",
+          "expr": "sum(rate(mattermost_websocket_broadcasts_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, name)",
           "interval": "",
           "legendFormat": "{{name}}",
           "range": true,
@@ -353,7 +353,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(mattermost_websocket_reconnects_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[10m])) by (juju_model, juju_application, juju_unit)",
+          "expr": "sum(increase(mattermost_websocket_reconnects_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit)",
           "legendFormat": "{{juju_unit}}",
           "range": true,
           "refId": "A"
@@ -449,7 +449,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(mattermost_websocket_event_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, type)",
+          "expr": "sum(rate(mattermost_websocket_event_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, type)",
           "legendFormat": "{{type}}",
           "range": true,
           "refId": "A"
@@ -570,7 +570,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_http_requests_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m])) by (juju_model, juju_application, juju_unit)",
+          "expr": "sum(rate(mattermost_http_requests_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit)",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -580,7 +580,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_http_requests_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m]))",
+          "expr": "sum(rate(mattermost_http_requests_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -675,7 +675,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_db_store_time_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit)",
+          "expr": "sum(rate(mattermost_db_store_time_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit)",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -685,7 +685,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_db_store_time_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
+          "expr": "sum(rate(mattermost_db_store_time_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -781,7 +781,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
           "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
@@ -791,7 +791,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(mattermost_api_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_api_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
           "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
@@ -887,7 +887,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_db_store_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_db_store_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
           "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
@@ -897,7 +897,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(mattermost_db_store_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_db_store_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
           "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
@@ -992,7 +992,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_db_store_time_count{method=~\"$top_db_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
+          "expr": "sum(increase(mattermost_db_store_time_count{method=~\"$top_db_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, method)",
           "interval": "",
           "legendFormat": "{{method}}",
           "refId": "A"
@@ -1087,7 +1087,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_api_time_count{handler=~\"$top_api_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
+          "expr": "sum(increase(mattermost_api_time_count{handler=~\"$top_api_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, handler)",
           "interval": "",
           "legendFormat": "{{handler}}",
           "refId": "A"
@@ -1186,7 +1186,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_db_store_time_sum{method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, method) / sum(increase(mattermost_db_store_time_count{method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
+          "expr": "sum(increase(mattermost_db_store_time_sum{method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, method) / sum(increase(mattermost_db_store_time_count{method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, method)",
           "interval": "",
           "legendFormat": "{{method}}",
           "refId": "A"
@@ -1285,7 +1285,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_api_time_sum{handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, handler) / sum(increase(mattermost_api_time_count{handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
+          "expr": "sum(increase(mattermost_api_time_sum{handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, handler) / sum(increase(mattermost_api_time_count{handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit, handler)",
           "interval": "",
           "legendFormat": "{{handler}}",
           "refId": "A"
@@ -1381,7 +1381,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])\n  )\n)",
           "interval": "",
           "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
@@ -1391,7 +1391,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])\n  )\n)",
           "interval": "",
           "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
@@ -1487,7 +1487,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])\n  )\n)",
           "interval": "",
           "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
@@ -1497,7 +1497,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])\n  )\n)",
           "interval": "",
           "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
@@ -1844,7 +1844,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_wait_count_total{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
+          "expr": "sum(rate(go_sql_wait_count_total{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "wait_count",
           "range": true,
@@ -1856,7 +1856,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=~\"replica.*\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=~\"replica.*\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "max_idle_closed",
           "range": true,
@@ -1868,7 +1868,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=~\"replica.*\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=~\"replica.*\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "max_idle_time_closed",
           "range": true,
@@ -1989,7 +1989,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_wait_count_total{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
+          "expr": "sum(rate(go_sql_wait_count_total{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "wait_count",
           "range": true,
@@ -2001,7 +2001,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "max_idle_closed",
           "range": true,
@@ -2013,7 +2013,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=\"master\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=\"master\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "max_idle_time_closed",
           "range": true,
@@ -2328,7 +2328,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (le, juju_model, juju_application, juju_unit))",
           "interval": "",
           "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
@@ -2338,7 +2338,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (le, juju_model, juju_application, juju_unit))",
           "interval": "",
           "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
@@ -2433,7 +2433,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit)",
+          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (juju_model, juju_application, juju_unit)",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"
@@ -2443,7 +2443,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m]))",
+          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -2695,7 +2695,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "irate(mattermost_process_cpu_seconds_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])* 100",
+          "expr": "irate(mattermost_process_cpu_seconds_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[$__rate_interval])* 100",
           "interval": "",
           "legendFormat": "{{juju_unit}}",
           "refId": "A"

--- a/cos_custom/grafana_dashboards/mattermost.json
+++ b/cos_custom/grafana_dashboards/mattermost.json
@@ -1,14 +1,5 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
+  "__inputs": [],
   "__elements": {},
   "__requires": [
     {
@@ -160,7 +151,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.2.3",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
@@ -256,7 +247,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.2.3",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
@@ -265,7 +256,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(mattermost_websocket_broadcasts_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, name)",
+          "expr": "sum(rate(mattermost_websocket_broadcasts_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, name)",
           "interval": "",
           "legendFormat": "{{name}}",
           "range": true,
@@ -354,7 +345,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.2.3",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
@@ -362,8 +353,8 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(mattermost_websocket_reconnects_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[10m])) by (juju_model, juju_application, juju_unit)",
-          "legendFormat": "{{instance}}",
+          "expr": "sum(increase(mattermost_websocket_reconnects_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[10m])) by (juju_model, juju_application, juju_unit)",
+          "legendFormat": "{{juju_unit}}",
           "range": true,
           "refId": "A"
         }
@@ -450,7 +441,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.2.3",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
@@ -458,7 +449,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(mattermost_websocket_event_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, type)",
+          "expr": "sum(rate(mattermost_websocket_event_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_unit=~\"$juju_unit\"}[5m])) by (juju_model, juju_application, juju_unit, type)",
           "legendFormat": "{{type}}",
           "range": true,
           "refId": "A"
@@ -579,9 +570,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "rate(mattermost_http_requests_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])",
+          "expr": "rate(mattermost_http_requests_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])",
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{juju_unit}}",
           "refId": "A"
         },
         {
@@ -589,7 +580,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_http_requests_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m]))",
+          "expr": "sum(rate(mattermost_http_requests_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -684,9 +675,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_db_store_time_count{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit)",
+          "expr": "sum(rate(mattermost_db_store_time_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit)",
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{juju_unit}}",
           "refId": "A"
         },
         {
@@ -694,7 +685,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_db_store_time_count{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(mattermost_db_store_time_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -790,9 +781,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
-          "legendFormat": "p99-{{instance}}",
+          "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
         },
         {
@@ -800,9 +791,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(mattermost_api_time_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_api_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
-          "legendFormat": "p50-{{instance}}",
+          "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
         }
       ],
@@ -896,9 +887,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_db_store_time_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_db_store_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
-          "legendFormat": "p99-{{instance}}",
+          "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
         },
         {
@@ -906,9 +897,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(mattermost_db_store_time_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_db_store_time_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
           "interval": "",
-          "legendFormat": "p50-{{instance}}",
+          "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
         }
       ],
@@ -1001,7 +992,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_db_store_time_count{instance=~\"$server\",method=~\"$top_db_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
+          "expr": "sum(increase(mattermost_db_store_time_count{method=~\"$top_db_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
           "interval": "",
           "legendFormat": "{{method}}",
           "refId": "A"
@@ -1096,7 +1087,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_api_time_count{instance=~\"$server\",handler=~\"$top_api_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
+          "expr": "sum(increase(mattermost_api_time_count{handler=~\"$top_api_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
           "interval": "",
           "legendFormat": "{{handler}}",
           "refId": "A"
@@ -1195,7 +1186,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_db_store_time_sum{instance=~\"$server\",method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method) / sum(increase(mattermost_db_store_time_count{instance=~\"$server\",method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
+          "expr": "sum(increase(mattermost_db_store_time_sum{method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method) / sum(increase(mattermost_db_store_time_count{method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
           "interval": "",
           "legendFormat": "{{method}}",
           "refId": "A"
@@ -1294,7 +1285,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(increase(mattermost_api_time_sum{instance=~\"$server\",handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler) / sum(increase(mattermost_api_time_count{instance=~\"$server\",handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
+          "expr": "sum(increase(mattermost_api_time_sum{handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler) / sum(increase(mattermost_api_time_count{handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
           "interval": "",
           "legendFormat": "{{handler}}",
           "refId": "A"
@@ -1390,9 +1381,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{instance=~\"$server\",handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
           "interval": "",
-          "legendFormat": "p99-{{instance}}",
+          "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
         },
         {
@@ -1400,9 +1391,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{instance=~\"$server\",handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
           "interval": "",
-          "legendFormat": "p50-{{instance}}",
+          "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
         }
       ],
@@ -1496,9 +1487,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{instance=~\"$server\",handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
           "interval": "",
-          "legendFormat": "p99-{{instance}}",
+          "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
         },
         {
@@ -1506,9 +1497,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{instance=~\"$server\",handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
           "interval": "",
-          "legendFormat": "p50-{{instance}}",
+          "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
         }
       ],
@@ -1604,9 +1595,9 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "mattermost_http_websockets_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "mattermost_http_websockets_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
           "interval": "",
-          "legendFormat": "{{instance}} - {{ origin_client}}",
+          "legendFormat": "{{juju_unit}} - {{ origin_client}}",
           "range": true,
           "refId": "A"
         },
@@ -1615,7 +1606,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(mattermost_http_websockets_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(mattermost_http_websockets_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -1626,7 +1617,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(mattermost_http_websockets_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}) by (juju_model, juju_application, juju_unit, origin_client)",
+          "expr": "sum(mattermost_http_websockets_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}) by (juju_model, juju_application, juju_unit, origin_client)",
           "hide": false,
           "interval": "",
           "legendFormat": "Total - {{ origin_client }}",
@@ -1865,7 +1856,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=~\"replica.*\",instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=~\"replica.*\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
           "hide": false,
           "legendFormat": "max_idle_closed",
           "range": true,
@@ -1877,7 +1868,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=~\"replica.*\",instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=~\"replica.*\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
           "hide": false,
           "legendFormat": "max_idle_time_closed",
           "range": true,
@@ -2022,7 +2013,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=\"master\",instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=\"master\",juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
           "hide": false,
           "legendFormat": "max_idle_time_closed",
           "range": true,
@@ -2119,9 +2110,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "mattermost_db_replica_lag_time{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "mattermost_db_replica_lag_time{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{juju_unit}}",
           "refId": "A"
         }
       ],
@@ -2241,9 +2232,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "mattermost_cluster_cluster_health_score{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "mattermost_cluster_cluster_health_score{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{juju_unit}}",
           "refId": "A"
         }
       ],
@@ -2337,9 +2328,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
           "interval": "",
-          "legendFormat": "p99-{{instance}}",
+          "legendFormat": "p99-{{juju_unit}}",
           "refId": "A"
         },
         {
@@ -2347,9 +2338,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
           "interval": "",
-          "legendFormat": "p50-{{instance}}",
+          "legendFormat": "p50-{{juju_unit}}",
           "refId": "B"
         }
       ],
@@ -2442,9 +2433,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit)",
+          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit)",
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{juju_unit}}",
           "refId": "A"
         },
         {
@@ -2452,7 +2443,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -2573,9 +2564,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "mattermost_jobs_active{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "mattermost_jobs_active{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{juju_unit}}",
           "refId": "A"
         },
         {
@@ -2583,7 +2574,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(mattermost_jobs_active{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(mattermost_jobs_active{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -2704,9 +2695,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "irate(mattermost_process_cpu_seconds_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])* 100",
+          "expr": "irate(mattermost_process_cpu_seconds_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])* 100",
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{juju_unit}}",
           "refId": "A"
         }
       ],
@@ -2799,9 +2790,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "go_memstats_heap_inuse_bytes{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "go_memstats_heap_inuse_bytes{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{juju_unit}}",
           "refId": "A"
         }
       ],
@@ -2894,9 +2885,9 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "go_goroutines{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "expr": "go_goroutines{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{juju_unit}}",
           "refId": "A"
         },
         {
@@ -2904,7 +2895,7 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "expr": "sum(go_goroutines{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "expr": "sum(go_goroutines{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
@@ -2919,28 +2910,6 @@
   "tags": [],
   "templating": {
     "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "hide": 0,
-        "includeAll": true,
-        "label": "Loki datasource",
-        "multi": true,
-        "name": "lokids",
-        "options": [],
-        "query": "loki",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "type": "datasource"
-      },
       {
         "current": {
           "selected": false,
@@ -2977,50 +2946,15 @@
         "datasource": {
           "uid": "${prometheusds}"
         },
-        "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+        "definition": "label_values(up,juju_model)",
         "hide": 0,
         "includeAll": true,
-        "label": "Juju unit",
+        "label": "Juju model",
         "multi": true,
-        "name": "juju_unit",
+        "name": "juju_model",
         "options": [],
         "query": {
-          "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": {
-          "uid": "${prometheusds}"
-        },
-        "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Juju application",
-        "multi": true,
-        "name": "juju_application",
-        "options": [],
-        "query": {
-          "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
+          "query": "label_values(up,juju_model)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -3082,15 +3016,15 @@
         "datasource": {
           "uid": "${prometheusds}"
         },
-        "definition": "label_values(up,juju_model)",
+        "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
         "hide": 0,
         "includeAll": true,
-        "label": "Juju model",
+        "label": "Juju application",
         "multi": true,
-        "name": "juju_model",
+        "name": "juju_application",
         "options": [],
         "query": {
-          "query": "label_values(up,juju_model)",
+          "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -3102,6 +3036,165 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju unit",
+        "multi": true,
+        "name": "juju_unit",
+        "options": [],
+        "query": {
+          "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(mattermost_db_store_time_count{juju_model=~\"$juju_model\",juju_application=~\"$juju_application\"}, method)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Top DB Count Filter",
+        "multi": true,
+        "name": "top_db_count",
+        "options": [],
+        "query": {
+          "query": "label_values(mattermost_db_store_time_count{juju_model=~\"$juju_model\",juju_application=~\"$juju_application\"}, method)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(mattermost_db_store_time_sum{juju_model=~\"$juju_model\",juju_application=~\"$juju_application\"}, method)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Top DB Latency Filter",
+        "multi": true,
+        "name": "top_db_latency",
+        "options": [],
+        "query": {
+          "query": "label_values(mattermost_db_store_time_sum{juju_model=~\"$juju_model\",juju_application=~\"$juju_application\"}, method)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(mattermost_api_time_count{juju_model=~\"$juju_model\",juju_application=~\"$juju_application\"}, handler)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Top API Count Filter",
+        "multi": true,
+        "name": "top_api_count",
+        "options": [],
+        "query": {
+          "query": "label_values(mattermost_api_time_count{juju_model=~\"$juju_model\",juju_application=~\"$juju_application\"}, handler)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(mattermost_api_time_sum{juju_model=~\"$juju_model\",juju_application=~\"$juju_application\"}, handler)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Top API Latency Filter",
+        "multi": true,
+        "name": "top_api_latency",
+        "options": [],
+        "query": {
+          "query": "label_values(mattermost_api_time_sum{juju_model=~\"$juju_model\",juju_application=~\"$juju_application\"}, handler)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },

--- a/cos_custom/grafana_dashboards/mattermost.json
+++ b/cos_custom/grafana_dashboards/mattermost.json
@@ -1,0 +1,3118 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.2.3"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "A dashboard to monitor complete Mattermost application performance",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 15582,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 53,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Websockets",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(mattermost_websocket_broadcast_buffer_size{juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"})",
+          "legendFormat": "Buffer size",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Websocket Buffer Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mattermost_websocket_broadcasts_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, name)",
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Websocket Broadcasts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(mattermost_websocket_reconnects_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[10m])) by (juju_model, juju_application, juju_unit)",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Websocket Reconnects",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 57,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(mattermost_websocket_event_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, type)",
+          "legendFormat": "{{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Websocket Events",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Application Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "rate(mattermost_http_requests_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(rate(mattermost_http_requests_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m]))",
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP Requests per second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(rate(mattermost_db_store_time_count{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit)",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(rate(mattermost_db_store_time_count{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "DB Calls per second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "interval": "",
+          "legendFormat": "p99-{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_api_time_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "interval": "",
+          "legendFormat": "p50-{{instance}}",
+          "refId": "B"
+        }
+      ],
+      "title": "API Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_db_store_time_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "interval": "",
+          "legendFormat": "p99-{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_db_store_time_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[1m])) by (juju_model, juju_application, juju_unit, le))",
+          "interval": "",
+          "legendFormat": "p50-{{instance}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Store latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(increase(mattermost_db_store_time_count{instance=~\"$server\",method=~\"$top_db_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
+          "interval": "",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 DB Calls by Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(increase(mattermost_api_time_count{instance=~\"$server\",handler=~\"$top_api_count\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
+          "interval": "",
+          "legendFormat": "{{handler}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 API Requests by Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(increase(mattermost_db_store_time_sum{instance=~\"$server\",method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method) / sum(increase(mattermost_db_store_time_count{instance=~\"$server\",method=~\"$top_db_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, method)",
+          "interval": "",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 DB calls by duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(increase(mattermost_api_time_sum{instance=~\"$server\",handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler) / sum(increase(mattermost_api_time_count{instance=~\"$server\",handler=~\"$top_api_latency\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit, handler)",
+          "interval": "",
+          "legendFormat": "{{handler}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 API requests by duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{instance=~\"$server\",handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "interval": "",
+          "legendFormat": "p99-{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{instance=~\"$server\",handler=\"getPostsForChannelAroundLastUnread\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "interval": "",
+          "legendFormat": "p50-{{instance}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Channel Load Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "histogram_quantile (\n  0.99,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{instance=~\"$server\",handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "interval": "",
+          "legendFormat": "p99-{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "histogram_quantile (\n  0.50,\n  sum by (le, juju_model, juju_application, juju_unit)(\n    rate(mattermost_api_time_bucket{instance=~\"$server\",handler=\"createPost\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])\n  )\n)",
+          "interval": "",
+          "legendFormat": "p50-{{instance}}",
+          "refId": "B"
+        }
+      ],
+      "title": "CreatePost duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 58
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "mattermost_http_websockets_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "interval": "",
+          "legendFormat": "{{instance}} - {{ origin_client}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(mattermost_http_websockets_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(mattermost_http_websockets_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}) by (juju_model, juju_application, juju_unit, origin_client)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total - {{ origin_client }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Number of connected devices (WebSocket Connections)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 58
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(mattermost_db_master_connections_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "interval": "",
+          "legendFormat": "master",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(mattermost_db_read_replica_connections_total{juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "interval": "",
+          "legendFormat": "replica",
+          "refId": "B"
+        }
+      ],
+      "title": "DB Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 66
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_sql_open_connections{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "hide": false,
+          "legendFormat": "open_conns",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_sql_in_use_connections{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "hide": false,
+          "legendFormat": "in_use_conns",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(go_sql_wait_count_total{db_name=~\"replica.*\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "hide": false,
+          "legendFormat": "wait_count",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=~\"replica.*\",instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "hide": false,
+          "legendFormat": "max_idle_closed",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=~\"replica.*\",instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "hide": false,
+          "legendFormat": "max_idle_time_closed",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Connection Pool (Replica)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 66
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_sql_open_connections{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "hide": false,
+          "legendFormat": "open_conns",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_sql_in_use_connections{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "hide": false,
+          "legendFormat": "in_use_conns",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(go_sql_wait_count_total{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "hide": false,
+          "legendFormat": "wait_count",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(go_sql_max_idle_closed_total{db_name=\"master\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "hide": false,
+          "legendFormat": "max_idle_closed",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(go_sql_max_idle_time_closed_total{db_name=\"master\",instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "hide": false,
+          "legendFormat": "max_idle_time_closed",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Connection Pool (Master)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "description": "This needs to be configured in config.json for it to work",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 75
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "mattermost_db_replica_lag_time{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replica Lag",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 83
+      },
+      "id": 36,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "description": "Lower numbers are better, and zero means \"totally healthy\".",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 84
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "mattermost_cluster_cluster_health_score{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Health",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 84
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
+          "interval": "",
+          "legendFormat": "p99-{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(mattermost_cluster_cluster_request_duration_seconds_bucket{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (le, juju_model, juju_application, juju_unit))",
+          "interval": "",
+          "legendFormat": "p50-{{instance}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Cluster Request Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 92
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])) by (juju_model, juju_application, juju_unit)",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(rate(mattermost_cluster_cluster_request_duration_seconds_count{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Cluster Requests Per Second",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 100
+      },
+      "id": 48,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Job Server",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 101
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "mattermost_jobs_active{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(mattermost_jobs_active{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Active Jobs",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 109
+      },
+      "id": 4,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "System Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 110
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "irate(mattermost_process_cpu_seconds_total{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}[5m])* 100",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Utilization Percentage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 110
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "go_memstats_heap_inuse_bytes{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Heap Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 119
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "go_goroutines{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "expr": "sum(go_goroutines{instance=~\"$server\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\"})",
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Loki datasource",
+        "multi": true,
+        "name": "lokids",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Prometheus datasource",
+        "multi": true,
+        "name": "prometheusds",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju unit",
+        "multi": true,
+        "name": "juju_unit",
+        "options": [],
+        "query": {
+          "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju application",
+        "multi": true,
+        "name": "juju_application",
+        "options": [],
+        "query": {
+          "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up{juju_model=~\"$juju_model\"},juju_model_uuid)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju model uuid",
+        "multi": true,
+        "name": "juju_model_uuid",
+        "options": [],
+        "query": {
+          "query": "label_values(up{juju_model=~\"$juju_model\"},juju_model_uuid)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up,juju_model)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju model",
+        "multi": true,
+        "name": "juju_model",
+        "options": [],
+        "query": {
+          "query": "label_values(up,juju_model)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Mattermost Performance Monitoring v2",
+  "uid": "im7xNX17kdd",
+  "version": 2,
+  "weekStart": ""
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-05-22
+
+- Add custom Grafana performance monitoring dashboard via `cos_custom` framework layout.
+
 ## 2026-04-30
 
 - Added SMTP integration.

--- a/docs/release-notes/artifacts/pr0062.yaml
+++ b/docs/release-notes/artifacts/pr0062.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Version of the artifact schema
+version_schema: 2
+
+# The key holding the change(s)
+changes:
+- title: Added custom Grafana performance monitoring dashboard
+  author: danielvnguyen
+  type: minor
+  description: Added an adapted Grafana dashboard via the cos_custom layout, providing out-of-the-box visibility into Mattermost API latency, database connection pools, and websocket performance.
+    pr: 
+      - "https://github.com/canonical/mattermost-k8s-operator/pull/62"
+    related_doc:
+    related_issue:
+  visibility: public
+  highlight: false


### PR DESCRIPTION
#### What this PR does
Adds a custom Grafana dashboard adapted from [Dashboard #15582](https://grafana.com/grafana/dashboards/15582-mattermost-performance-monitoring-v2/) via the cos_custom framework layout to monitor Mattermost performance metrics.

#### Why we need it
Provides operators with critical application-level visibility to detect database bottlenecks and monitor websocket scaling constraints in production.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [x] I added or updated tests as needed (unit and integration)
- [x] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [x] **If this is a Grafana dashboard:** I added a screenshot of the dashboard
- [x] **If this is Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [x] **If this is Rockcraft:** I updated the version

**Grafana Dashboard Screenshots**:
**Note**: To obtain data locally, I had to enable the 30-day Mattermost Enterprise Advanced Free Trial, enable Performance Monitoring & Client Performance Monitoring in the Mattermost System Console, and deploy `prometheus-scrape-target-k8s` so that Prometheus scrapes data from the correct Mattermost `/metrics` port.

Here is the full how-to guide documenting this process: [Mattermost - Enabling Local Observability](https://docs.google.com/document/d/1hHwuetY7b7imdQ7rr_8B8RIoPUSATIIhyL12T9pm68M/edit?usp=sharing)

The following panels are not displaying data because I could not produce the data locally:
- Websocket Reconnects
- Number of connected devices (WebSocket Connections)
- Connection Pool (Replica)
- Replica Lag

<img width="1717" height="1227" alt="Screenshot from 2026-05-27 15-30-55" src="https://github.com/user-attachments/assets/e4493845-9428-48b5-a528-3ae64dfb692c" />
<img width="1717" height="1227" alt="Screenshot from 2026-05-27 15-31-01" src="https://github.com/user-attachments/assets/7820051d-74c4-4939-bd0c-8f370891c2e3" />
<img width="1717" height="1227" alt="Screenshot from 2026-05-27 15-31-19" src="https://github.com/user-attachments/assets/69e0025b-3c40-49eb-994a-eb0af8bc36be" />
<img width="1717" height="1227" alt="Screenshot from 2026-05-27 15-31-32" src="https://github.com/user-attachments/assets/dfd97943-4db4-42f0-95f0-22d40273645f" />
<img width="1717" height="1227" alt="Screenshot from 2026-05-27 15-31-38" src="https://github.com/user-attachments/assets/8f1ba50e-a039-475d-9f34-138da2ada959" />

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->
