### PR TITLE
feat(prometheus): add custom prometheus alert rules (ISD-716)

### DIFF
--- a/cos_custom/prometheus_alert_rules/mattermost.rule
+++ b/cos_custom/prometheus_alert_rules/mattermost.rule
@@ -1,0 +1,50 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+groups:
+  - name: mattermost-prometheus-alerts
+    rules:
+      - alert: MattermostHighCpuUtilization
+        expr: rate(process_cpu_seconds_total[1m]) * 100 > 85
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: Mattermost High CPU Utilization
+          description: "Mattermost CPU utilization averaged over the last minute is above 85%."
+
+      - alert: MattermostHighMemoryUsage
+        expr: (avg_over_time(process_resident_memory_bytes[1m]) / 1024 / 1024) > 4000
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: Mattermost High Memory Usage
+          description: "Mattermost RAM usage averaged over the last minute is above 4000 MB."
+
+      - alert: MattermostHighGoroutinesCount
+        expr: avg_over_time(go_goroutines[1m]) > 5000
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: Mattermost Climbing Goroutines
+          description: "Mattermost active goroutines averaged over the last minute have exceeded 5,000, indicating potential thread lockup."
+
+      - alert: MattermostHighApiErrorsPerSecond
+        expr: sum by (instance) (rate(mattermost_api_time_count{status_code=~"[45].."}[1m])) > 10
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: High Mattermost API Errors Per Second
+          description: "Mattermost is experiencing more than 10 API errors (4xx/5xx) per second over the last minute."
+
+      - alert: MattermostHighMeanApiRequestTime
+        expr: (sum by (instance) (rate(mattermost_api_time_sum[1m])) / sum by (instance) (rate(mattermost_api_time_count[1m]))) > 1.5
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: High Mattermost API Request Latency
+          description: "The mean API request time is averaging above 1.5 seconds over the last minute."

--- a/cos_custom/prometheus_alert_rules/mattermost.rule
+++ b/cos_custom/prometheus_alert_rules/mattermost.rule
@@ -5,46 +5,46 @@ groups:
   - name: mattermost-prometheus-alerts
     rules:
       - alert: MattermostHighCpuUtilization
-        expr: rate(process_cpu_seconds_total[1m]) * 100 > 85
-        for: 1m
+        expr: rate(process_cpu_seconds_total[5m]) * 100 > 85
+        for: 5m
         labels:
           severity: warning
         annotations:
           summary: Mattermost High CPU Utilization
-          description: "Mattermost CPU utilization averaged over the last minute is above 85%."
+          description: "Mattermost CPU utilization averaged over the last 5 minutes is above 85%."
 
       - alert: MattermostHighMemoryUsage
-        expr: (avg_over_time(process_resident_memory_bytes[1m]) / 1024 / 1024) > 4000
-        for: 1m
+        expr: (avg_over_time(process_resident_memory_bytes[5m]) / 1024 / 1024) > 4000
+        for: 5m
         labels:
           severity: warning
         annotations:
           summary: Mattermost High Memory Usage
-          description: "Mattermost RAM usage averaged over the last minute is above 4000 MB."
+          description: "Mattermost RAM usage averaged over the last 5 minutes is above 4000 MB."
 
       - alert: MattermostHighGoroutinesCount
-        expr: avg_over_time(go_goroutines[1m]) > 5000
-        for: 1m
+        expr: avg_over_time(go_goroutines[5m]) > 5000
+        for: 5m
         labels:
           severity: warning
         annotations:
           summary: Mattermost Climbing Goroutines
-          description: "Mattermost active goroutines averaged over the last minute have exceeded 5,000, indicating potential thread lockup."
+          description: "Mattermost active goroutines averaged over the last 5 minutes have exceeded 5,000, indicating potential thread lockup."
 
       - alert: MattermostHighApiErrorsPerSecond
-        expr: sum by (instance) (rate(mattermost_api_time_count{status_code=~"[45].."}[1m])) > 10
-        for: 1m
+        expr: sum by (instance) (rate(mattermost_api_time_count{status_code=~"[45].."}[5m])) > 10
+        for: 5m
         labels:
           severity: critical
         annotations:
           summary: High Mattermost API Errors Per Second
-          description: "Mattermost is experiencing more than 10 API errors (4xx/5xx) per second over the last minute."
+          description: "Mattermost is experiencing more than 10 API errors (4xx/5xx) per second over the last 5 minutes."
 
       - alert: MattermostHighMeanApiRequestTime
-        expr: (sum by (instance) (rate(mattermost_api_time_sum[1m])) / sum by (instance) (rate(mattermost_api_time_count[1m]))) > 1.5
-        for: 1m
+        expr: (sum by (instance) (rate(mattermost_api_time_sum[5m])) / sum by (instance) (rate(mattermost_api_time_count[5m]))) > 1.5
+        for: 5m
         labels:
           severity: warning
         annotations:
           summary: High Mattermost API Request Latency
-          description: "The mean API request time is averaging above 1.5 seconds over the last minute."
+          description: "The mean API request time is averaging above 1.5 seconds over the last 5 minutes."

--- a/cos_custom/prometheus_alert_rules/mattermost.rule
+++ b/cos_custom/prometheus_alert_rules/mattermost.rule
@@ -33,7 +33,7 @@ groups:
 
       - alert: MattermostHighApiErrorsPerSecond
         expr: sum by (instance) (rate(mattermost_api_time_count{status_code=~"[45].."}[5m])) > 10
-        for: 5m
+        for: 1m
         labels:
           severity: critical
         annotations:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-03
+
+- Added custom Prometheus alert rules.
+
 ## 2026-05-09
 
 - Added the following configuration options:

--- a/docs/release-notes/artifacts/pr0066.yaml
+++ b/docs/release-notes/artifacts/pr0066.yaml
@@ -1,0 +1,17 @@
+# Version of the artifact schema
+version_schema: 2
+
+# The key holding the change(s)
+changes:
+- title: Added custom Prometheus alert rules
+  author: danielvnguyen
+  type: minor
+  description: Added Prometheus alert rules for core Mattermost metrics - covering API errors, latency, goroutine leaks, and memory bottlenecks.
+  urls:
+    pr: 
+      - "https://github.com/canonical/mattermost-k8s-operator/pull/66"
+    related_doc:
+    related_issue:
+  visibility: public
+  highlight: false
+

--- a/tests/unit/test_alerts.py
+++ b/tests/unit/test_alerts.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Learn more about testing at: https://ops.readthedocs.io/en/latest/explanation/testing.html
+
+"""Unit tests for alert rules."""
+
+import os
+import shutil
+import subprocess
+import pytest
+
+
+@pytest.mark.skipif(
+    not shutil.which("promtool"),
+    reason="promtool CLI tool not installed on this system",
+)
+def test_prometheus_alert_rules():
+    """
+    arrange: A defined set of Prometheus alert rules and a mock data test file.
+    act: Run the promtool unit testing engine via a subprocess call.
+    assert: The promtool exit code is 0, indicating all alert rules match the
+        expected firing states based on the mock metrics.
+    """
+    test_file_path = os.path.join("tests", "unit", "test_prometheus_alerts.yaml")
+
+    result = subprocess.run(
+        ["promtool", "test", "rules", test_file_path],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"Promtool verification failed:\n{result.stderr}\n{result.stdout}"

--- a/tests/unit/test_prometheus_alerts.yaml
+++ b/tests/unit/test_prometheus_alerts.yaml
@@ -1,0 +1,78 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+rule_files:
+  - ../../cos_custom/prometheus_alert_rules/mattermost.rule
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'process_cpu_seconds_total{instance="mattermost-0"}'
+        values: '0+0x3 60+60x5'
+      - series: 'process_resident_memory_bytes{instance="mattermost-0"}'
+        values: '1000000000+0x3 4500000000+0x5'
+      - series: 'go_goroutines{instance="mattermost-0"}'
+        values: '1000+0x3 6000+0x5' 
+      - series: 'mattermost_api_time_count{instance="mattermost-0", status_code="500"}'
+        values: '0+0x3 1000+1000x5' 
+      - series: 'mattermost_api_time_sum{instance="mattermost-0", status_code="500"}'
+        values: '0+0x3 2000+2000x5'
+
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: MattermostHighCpuUtilization
+        exp_alerts: []
+      - eval_time: 3m
+        alertname: MattermostHighMemoryUsage
+        exp_alerts: []
+      - eval_time: 3m
+        alertname: MattermostHighGoroutinesCount
+        exp_alerts: []
+      - eval_time: 3m
+        alertname: MattermostHighApiErrorsPerSecond
+        exp_alerts: []
+      - eval_time: 3m
+        alertname: MattermostHighMeanApiRequestTime
+        exp_alerts: []
+
+      - eval_time: 6m
+        alertname: MattermostHighCpuUtilization
+        exp_alerts:
+          - exp_labels: { severity: warning, instance: mattermost-0 }
+            exp_annotations:
+              summary: "Mattermost High CPU Utilization"
+              description: "Mattermost CPU utilization averaged over the last minute is above 85%."
+
+      - eval_time: 6m
+        alertname: MattermostHighMemoryUsage
+        exp_alerts:
+          - exp_labels: { severity: warning, instance: mattermost-0 }
+            exp_annotations:
+              summary: "Mattermost High Memory Usage"
+              description: "Mattermost RAM usage averaged over the last minute is above 4000 MB."
+
+      - eval_time: 6m
+        alertname: MattermostHighGoroutinesCount
+        exp_alerts:
+          - exp_labels: { severity: warning, instance: mattermost-0 }
+            exp_annotations:
+              summary: "Mattermost Climbing Goroutines"
+              description: "Mattermost active goroutines averaged over the last minute have exceeded 5,000, indicating potential thread lockup."
+
+      - eval_time: 6m
+        alertname: MattermostHighApiErrorsPerSecond
+        exp_alerts:
+          - exp_labels: { severity: critical, instance: mattermost-0 }
+            exp_annotations:
+              summary: "High Mattermost API Errors Per Second"
+              description: "Mattermost is experiencing more than 10 API errors (4xx/5xx) per second over the last minute."
+
+      - eval_time: 6m
+        alertname: MattermostHighMeanApiRequestTime
+        exp_alerts:
+          - exp_labels: { severity: warning, instance: mattermost-0 }
+            exp_annotations:
+              summary: "High Mattermost API Request Latency"
+              description: "The mean API request time is averaging above 1.5 seconds over the last minute."

--- a/tests/unit/test_prometheus_alerts.yaml
+++ b/tests/unit/test_prometheus_alerts.yaml
@@ -4,75 +4,75 @@
 rule_files:
   - ../../cos_custom/prometheus_alert_rules/mattermost.rule
 
-evaluation_interval: 1m
+evaluation_interval: 5m
 
 tests:
   - interval: 1m
     input_series:
       - series: 'process_cpu_seconds_total{instance="mattermost-0"}'
-        values: '0+0x3 60+60x5'
+        values: '0+0x5 60+60x15'
       - series: 'process_resident_memory_bytes{instance="mattermost-0"}'
-        values: '1000000000+0x3 4500000000+0x5'
+        values: '1000000000+0x5 5500000000+0x15'
       - series: 'go_goroutines{instance="mattermost-0"}'
-        values: '1000+0x3 6000+0x5' 
+        values: '1000+0x5 6000+0x15' 
       - series: 'mattermost_api_time_count{instance="mattermost-0", status_code="500"}'
-        values: '0+0x3 1000+1000x5' 
+        values: '0+0x5 1000+1000x15' 
       - series: 'mattermost_api_time_sum{instance="mattermost-0", status_code="500"}'
-        values: '0+0x3 2000+2000x5'
+        values: '0+0x5 2000+2000x15'
 
     alert_rule_test:
-      - eval_time: 3m
+      - eval_time: 8m
         alertname: MattermostHighCpuUtilization
         exp_alerts: []
-      - eval_time: 3m
+      - eval_time: 8m
         alertname: MattermostHighMemoryUsage
         exp_alerts: []
-      - eval_time: 3m
+      - eval_time: 8m
         alertname: MattermostHighGoroutinesCount
         exp_alerts: []
-      - eval_time: 3m
+      - eval_time: 8m
         alertname: MattermostHighApiErrorsPerSecond
         exp_alerts: []
-      - eval_time: 3m
+      - eval_time: 8m
         alertname: MattermostHighMeanApiRequestTime
         exp_alerts: []
 
-      - eval_time: 6m
+      - eval_time: 16m
         alertname: MattermostHighCpuUtilization
         exp_alerts:
           - exp_labels: { severity: warning, instance: mattermost-0 }
             exp_annotations:
               summary: "Mattermost High CPU Utilization"
-              description: "Mattermost CPU utilization averaged over the last minute is above 85%."
+              description: "Mattermost CPU utilization averaged over the last 5 minutes is above 85%."
 
-      - eval_time: 6m
+      - eval_time: 16m
         alertname: MattermostHighMemoryUsage
         exp_alerts:
           - exp_labels: { severity: warning, instance: mattermost-0 }
             exp_annotations:
               summary: "Mattermost High Memory Usage"
-              description: "Mattermost RAM usage averaged over the last minute is above 4000 MB."
+              description: "Mattermost RAM usage averaged over the last 5 minutes is above 4000 MB."
 
-      - eval_time: 6m
+      - eval_time: 16m
         alertname: MattermostHighGoroutinesCount
         exp_alerts:
           - exp_labels: { severity: warning, instance: mattermost-0 }
             exp_annotations:
               summary: "Mattermost Climbing Goroutines"
-              description: "Mattermost active goroutines averaged over the last minute have exceeded 5,000, indicating potential thread lockup."
+              description: "Mattermost active goroutines averaged over the last 5 minutes have exceeded 5,000, indicating potential thread lockup."
 
-      - eval_time: 6m
+      - eval_time: 16m
         alertname: MattermostHighApiErrorsPerSecond
         exp_alerts:
           - exp_labels: { severity: critical, instance: mattermost-0 }
             exp_annotations:
               summary: "High Mattermost API Errors Per Second"
-              description: "Mattermost is experiencing more than 10 API errors (4xx/5xx) per second over the last minute."
+              description: "Mattermost is experiencing more than 10 API errors (4xx/5xx) per second over the last 5 minutes."
 
-      - eval_time: 6m
+      - eval_time: 16m
         alertname: MattermostHighMeanApiRequestTime
         exp_alerts:
           - exp_labels: { severity: warning, instance: mattermost-0 }
             exp_annotations:
               summary: "High Mattermost API Request Latency"
-              description: "The mean API request time is averaging above 1.5 seconds over the last minute."
+              description: "The mean API request time is averaging above 1.5 seconds over the last 5 minutes."

--- a/tests/unit/test_prometheus_alerts.yaml
+++ b/tests/unit/test_prometheus_alerts.yaml
@@ -4,7 +4,7 @@
 rule_files:
   - ../../cos_custom/prometheus_alert_rules/mattermost.rule
 
-evaluation_interval: 5m
+evaluation_interval: 1m
 
 tests:
   - interval: 1m
@@ -37,6 +37,14 @@ tests:
         alertname: MattermostHighMeanApiRequestTime
         exp_alerts: []
 
+      - eval_time: 12m
+        alertname: MattermostHighApiErrorsPerSecond
+        exp_alerts:
+          - exp_labels: { severity: critical, instance: mattermost-0 }
+            exp_annotations:
+              summary: "High Mattermost API Errors Per Second"
+              description: "Mattermost is experiencing more than 10 API errors (4xx/5xx) per second over the last 5 minutes."
+
       - eval_time: 16m
         alertname: MattermostHighCpuUtilization
         exp_alerts:
@@ -60,14 +68,6 @@ tests:
             exp_annotations:
               summary: "Mattermost Climbing Goroutines"
               description: "Mattermost active goroutines averaged over the last 5 minutes have exceeded 5,000, indicating potential thread lockup."
-
-      - eval_time: 16m
-        alertname: MattermostHighApiErrorsPerSecond
-        exp_alerts:
-          - exp_labels: { severity: critical, instance: mattermost-0 }
-            exp_annotations:
-              summary: "High Mattermost API Errors Per Second"
-              description: "Mattermost is experiencing more than 10 API errors (4xx/5xx) per second over the last 5 minutes."
 
       - eval_time: 16m
         alertname: MattermostHighMeanApiRequestTime


### PR DESCRIPTION
#### What this PR does

Adds Prometheus alert rules for core Mattermost metrics along with a `promtool` unit test suite integrated directly into the Python testing pipeline.

#### Why we need it

The default observability assets only monitor underlying infrastructure health, leaving operations completely blind to critical Mattermost application-level failures, database disconnects, and performance regressions.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [x] I added or updated tests as needed (unit and integration)
- [x] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [x] **If this is a Grafana dashboard:** I added a screenshot of the dashboard
- [x] **If this is Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [x] **If this is Rockcraft:** I updated the version

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

========================================================================================

**Note:** I chose these alert rules based on pre-configured alerts that used to be included in Grafana Mattermost dashboards.
- Learn more here: https://docs.mattermost.com/administration-guide/scale/performance-alerting.html

**Threshold Justifications**:
- Thresholds are tuned based on baseline expectations for a mid-sized enterprise footprint (~1,500 users).
- `Mattermost High CPU Utilization`: Triggers when CPU utilization over the last minute is above 85%.
  - During peak log-ins, 1,500 users might briefly push CPU to 40-50%. A sustained 85% for a full 5 minutes means the server is genuinely thrashing or a plugin is stuck.
- `Mattermost High Memory Usage`: Triggers if RAM usage averaged over the last 5 minutes is above 4000 MB (4 GB).
  - This depends on the amount of node memory allocated. I am assuming a single 8 GB node, so this alert fires at 50% memory usage.
- `Mattermost Climbing Goroutines`: Triggers if the number of active goroutines averaged over the last 5 minutes exceeds 5,000, indicating potential thread lockup.
  - There should be one goroutine (Websocket connection) per user / computer, so 5,000 is a good ceiling for a mid-sized company.
- `High Mattermost API Errors Per Second`: Triggers if there is more than 10 4xx or 5xx API errors over the last 5 minutes.
  - 1,500 active employees generate roughly 30–60 normal API requests per second at peak. If 10 of those _per second_ are errors, up to 30% of the users are broken.
- `High Mattermost API Request Latency`: Triggers if the mean API request time is averaging above 1.5 seconds over the last 5 minutes.
  - Mattermost interaction should feel instant (<200ms). If the average request takes 1.5 seconds, the app will feel completely frozen.