### PR TITLE
chore: update Mattermost rock to v11.7.7

### DIFF
--- a/docs/release-notes/artifacts/pr0076.yaml
+++ b/docs/release-notes/artifacts/pr0076.yaml
@@ -1,0 +1,22 @@
+# Version of the artifact schema
+version_schema: 2
+
+# The key holding the change(s)
+changes:
+- title: Upgrade Mattermost workload to v11.7.7 (latest ESR)
+  author: sbouffard
+  type: minor
+  description: |
+    Bumped the Mattermost server from 11.7.6 to 11.7.7 (latest Extended Support
+    Release). Community plugin pins remain at current upstream releases
+    (autolink v1.4.1, matterpoll v1.8.0, giphy v5.0.0, remind v1.0.0).
+    Prepackaged plugins shipped by the Mattermost tarball were updated as part
+    of the server bump, including jira v4.7.1 (from v4.7.0), playbooks v2.9.2
+    (from v2.9.1), and boards v9.2.6 (from v9.2.4).
+  urls:
+    pr:
+      - "https://github.com/canonical/mattermost-k8s-operator/pull/76"
+    related_doc:
+    related_issue:
+  visibility: public
+  highlight: false

--- a/docs/release-notes/artifacts/pr0081.yaml
+++ b/docs/release-notes/artifacts/pr0081.yaml
@@ -15,7 +15,7 @@ changes:
     (from v2.9.1), and boards v9.2.6 (from v9.2.4).
   urls:
     pr:
-      - "https://github.com/canonical/mattermost-k8s-operator/pull/76"
+      - "https://github.com/canonical/mattermost-k8s-operator/pull/81"
     related_doc:
     related_issue:
   visibility: public

--- a/mattermost_rock/rockcraft.yaml
+++ b/mattermost_rock/rockcraft.yaml
@@ -3,7 +3,7 @@
 
 name: mattermost
 base: ubuntu@24.04
-version: '11.7.6-1'
+version: '11.7.7-1'
 summary: Mattermost is an open source, self-hosted Slack-alternative.
 description: |
   Mattermost offers secure, flexible, and integrated messaging 
@@ -39,7 +39,7 @@ parts:
   # ---------------------------------------------------------
   mattermost:
     plugin: dump
-    source: https://releases.mattermost.com/11.7.6/mattermost-11.7.6-linux-amd64.tar.gz
+    source: https://releases.mattermost.com/11.7.7/mattermost-11.7.7-linux-amd64.tar.gz
     source-type: tar
     organize:
       bin: app/bin


### PR DESCRIPTION
## Summary
- bump Mattermost rock version to `11.7.7-1`
- update Mattermost source tarball to `11.7.7`

## Plugin impact
- community plugin pins are unchanged and remain current:
  - autolink `v1.4.1`
  - matterpoll `v1.8.0`
  - giphy `v5.0.0`
  - remind `v1.0.0`
- prepackaged plugins updated via upstream Mattermost `11.7.7` tarball:
  - jira `v4.7.0` -> `v4.7.1`
  - playbooks `v2.9.1` -> `v2.9.2`
  - boards `v9.2.4` -> `v9.2.6`

## Testing
- not run (version and release-note artifact update only)